### PR TITLE
Use emby server's embedded ffmpeg build

### DIFF
--- a/overlay/usr/local/etc/rc.d/emby-server
+++ b/overlay/usr/local/etc/rc.d/emby-server
@@ -42,8 +42,8 @@ load_rc_config ${name}
 : ${emby_server_user:="emby"}
 : ${emby_server_group:="emby"}
 : ${emby_server_data_dir:="/var/db/emby-server"}
-: ${emby_server_ffmpeg:="/usr/local/bin/ffmpeg"}
-: ${emby_server_ffprobe:="/usr/local/bin/ffprobe"}
+: ${emby_server_ffmpeg:="/usr/local/lib/emby-server/bin/ffmpeg"}
+: ${emby_server_ffprobe:="/usr/local/lib/emby-server/bin/ffprobe"}
 
 export LD_LIBRARY_PATH=/usr/local/lib
 


### PR DESCRIPTION
This will improve the experience for FreeNAS users by making our custom functions available. I see from here that this change was originally made due to troubleshooting:
https://redmine.ixsystems.com/issues/62628
If any issues arise we'll be happy to help users work through them. Thanks.